### PR TITLE
Fix glob call

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = bundler => {
         const createLocationTag = url =>
             `<url><loc>${siteURL}${path.relative(outDir, url)}</loc></url>`;
 
-        const htmlFiles = await glob.async(htmlGlobs);
+        const htmlFiles = await glob(htmlGlobs);
         const sitemap = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${htmlFiles
             .sort() // keep order stable, mainly to allow for reliable testing
             .map(createLocationTag)}</urlset>`;


### PR DESCRIPTION
The `async` method is removed from fast-glob since version 3.0.0. So, there is an exception in the plugin.

https://github.com/mrmlnc/fast-glob/releases/tag/3.0.0